### PR TITLE
Allow (EQL NIL) typespec

### DIFF
--- a/src/cmp/cmpopt.lsp
+++ b/src/cmp/cmpopt.lsp
@@ -72,8 +72,9 @@
 	     (cmperr "Invalid SATISFIES typespec: ~S" type))
 	   `(if (funcall #',function ,object) t nil))
 	  ((eq first 'EQL)
-	   (unless (and (setq aux (car rest)) (endp (cdr rest)))
+	   (unless (endp (cdr rest))
 	     (cmperr "Invalid EQL typespec: ~S" type))
+           (setq aux (car rest))
 	   `(,(if (numberp aux) 'EQL 'EQ) ,aux ,object)
 	   )
 	  ;;


### PR DESCRIPTION
EXPAND-TYPEP currently requires the second argument of the EQL typespec to be non-NIL which excludes the valid typespec `(eql nil)`.