### PR TITLE
Check for :EOF in mk_clos_stream_read_char

### DIFF
--- a/src/c/file.c
+++ b/src/c/file.c
@@ -1388,7 +1388,7 @@ mk_clos_stream_read_char(MKCL, mkcl_object strm)
     value = MKCL_CHAR_CODE(output);
   else if (MKCL_FIXNUMP(output))
     value = mkcl_fixnum_to_word(output);
-  else if (output == mk_cl_Cnil)
+  else if ((output == mk_cl_Cnil) || ((mkcl_object) &MK_KEY_eof))
     return EOF;
   else
     value = -1;


### PR DESCRIPTION
The Gray stream protocol defines `:EOF` as the proper return from stream-read-char on EOF. I left the check for NIL as this what ECL and CLASP do and it seems relatively harmless.

```
  STREAM-READ-CHAR  stream			[Generic Function]

    This reads one character from the stream.  It returns either a
    character object, or the symbol :EOF if the stream is at end-of-file.
    Every subclass of FUNDAMENTAL-CHARACTER-INPUT-STREAM must define a
    method for this function.
```