### PR TITLE
Revert "Check for :EOF in mk_clos_stream_read_char (#15)"

### DIFF
--- a/src/c/file.c
+++ b/src/c/file.c
@@ -1388,7 +1388,7 @@ mk_clos_stream_read_char(MKCL, mkcl_object strm)
     value = MKCL_CHAR_CODE(output);
   else if (MKCL_FIXNUMP(output))
     value = mkcl_fixnum_to_word(output);
-  else if ((output == mk_cl_Cnil) || ((mkcl_object) &MK_KEY_eof))
+  else if (output == mk_cl_Cnil)
     return EOF;
   else
     value = -1;


### PR DESCRIPTION
This reverts commit 42c9aee0e4cb05113a97f509e459e8466ac04150.