### PR TITLE
Return nil from stream-terpri

### DIFF
--- a/src/clos/streams.lsp
+++ b/src/clos/streams.lsp
@@ -611,7 +611,8 @@
 ;; TERPRI
 
 (defmethod stream-terpri ((stream fundamental-character-output-stream))
-  (stream-write-char stream #\Newline))
+  (stream-write-char stream #\Newline)
+  nil)
 
 (defmethod stream-terpri ((stream ansi-stream))
   (cl:terpri stream))


### PR DESCRIPTION
As mentioned in the docstring for stream-terpi and in the [Gray stream protocol proposal](http://www.nhplace.com/kent/CL/Issues/stream-definition-by-user.html) it should return NIL.