### PR TITLE
&rest processing for mk_si_make_structure and mk_si_put_properties

### DIFF
--- a/src/c/structure.c
+++ b/src/c/structure.c
@@ -70,7 +70,7 @@ mkcl_object mk_si_make_structure(MKCL, mkcl_narg narg, mkcl_object type, ...)
 
   mkcl_call_stack_check(env);
   {
-    mkcl_setup_for_rest(env, (mkcl_object) &MK_SI_make_structure, 0, narg, type, args);
+    mkcl_setup_for_rest(env, (mkcl_object) &MK_SI_make_structure, 1, narg, type, args);
 
     x = mkcl_alloc_raw_structure(env, type, --narg);
 

--- a/src/c/symbol.c
+++ b/src/c/symbol.c
@@ -601,7 +601,7 @@ mkcl_object mk_si_put_properties(MKCL, mkcl_narg narg, mkcl_object sym, ...)
 {
   mkcl_call_stack_check(env);
   {
-    mkcl_setup_for_rest(env, (mkcl_object) &MK_SI_put_properties, 0, narg, sym, ind_values);
+    mkcl_setup_for_rest(env, (mkcl_object) &MK_SI_put_properties, 1, narg, sym, ind_values);
 
     while (--narg >= 2) {
       mkcl_object prop = mkcl_va_arg(ind_values);

--- a/src/cmp/sysfun.lsp
+++ b/src/cmp/sysfun.lsp
@@ -641,7 +641,7 @@
     #+(or x86-64 aarch64)
     (def-inline si:row-major-aset :always ((array mkcl:natural32) fixnum fixnum) :fixnum "mkcl_fixnum_to_word(mkcl_aset_index_b32(env, #0, #1, MKCL_MAKE_FIXNUM(#2)))")
     #+(or x86-64 aarch64)
-    (def-inline si:row-major-aset :always ((array mkcl:natural32) fixnum fixnum) :void "mkcl_aset_index_b32(env, #0, #1, MKCL_MAKE_FIXNUM(#2)))")
+    (def-inline si:row-major-aset :always ((array mkcl:natural32) fixnum fixnum) :void "mkcl_aset_index_b32(env, #0, #1, MKCL_MAKE_FIXNUM(#2))")
     #+(or x86-64 aarch64)
     (def-inline si:row-major-aset :always ((array mkcl:natural32) fixnum mkcl:natural32) :uint32-t "mkcl_aset_index_b32_raw(env, #0, #1, #2)")
     (def-inline si:row-major-aset :always ((array mkcl:integer32) fixnum fixnum) :fixnum "mkcl_fixnum_to_word(mkcl_aset_index_i32(env, #0, #1, MKCL_MAKE_FIXNUM(#2)))")


### PR DESCRIPTION
When I saw that a `defstruct` with 63 or more slots wasn't processed correctly, I suspected that it was hitting a stack limit, namely `si:c-arguments-limit`. Adjusting the `min_arg` argument to `mkcl_setup_for_rest` solves the problem, as it calls `mkcl_va_start` to set the stack pointer. A similar fix is for `si:put-properties`.